### PR TITLE
Release 0.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xnumpy" %}
-{% set version = "0.0.1" %}
-{% set sha256 = "4649c57a404e1ab9429d33f9d63c82a5cccb8a72cf524d130176c3b0dd59af96" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "dc0cf3ed57c8b4c4dfc063dec9bb0d707635f054a5b06d4542ffc2a9126c8a2e" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```
* Add `indices` as a quick replacement for `numpy.indices`.
* Attempt to setup Travis CI's automatic PyPI deployments.
```
