### PR TITLE
Release 0.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xnumpy" %}
-{% set version = "0.1.0" %}
-{% set sha256 = "dc0cf3ed57c8b4c4dfc063dec9bb0d707635f054a5b06d4542ffc2a9126c8a2e" %}
+{% set version = "0.1.2" %}
+{% set sha256 = "31e7f1100f57cb74048fca9ce0493353d2583c85eea779845bcf51de11b23bfa" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,14 @@ requirements:
     - numpy
 
 test:
+  source_files:
+    - tests
+
   imports:
     - xnumpy
+
+  commands:
+    - python -m unittest discover -s .
 
 about:
   home: https://github.com/jakirkham/xnumpy


### PR DESCRIPTION
```markdown
### v0.1.2

* Drop spaces around keyword argument. #8
* Reuse arrays in doctests. #10
* Flatten `indices` default dtype check. #12
* Fix doctests on Windows. #11
```

```markdown
### v0.1.1

* Upgrade versioneer to 0.17. #4
* Extend license copyright into 2017. #5
* Update copyright years in docs. #6
* Recut with cookiecutter. #7
```

Note: Replaces PR ( https://github.com/conda-forge/xnumpy-feedstock/pull/4 ).